### PR TITLE
Use alpine runtime instead of debian

### DIFF
--- a/src/EBookPresenter/Dockerfile
+++ b/src/EBookPresenter/Dockerfile
@@ -7,7 +7,8 @@ COPY . .
 RUN dotnet publish -c release -o /app
 
 # final stage/image
-FROM mcr.microsoft.com/dotnet/aspnet:5.0
+FROM mcr.microsoft.com/dotnet/aspnet:5.0-alpine
+
 WORKDIR /app
 COPY --from=build /app .
 ENTRYPOINT ["dotnet", "EBookPresenter.dll"]


### PR DESCRIPTION
Use Alpine Linux container for the runtime rather than the default debian and save somewhere along the lines of 80-100 mb in space along side the benefits of less running in the container (i.e. safer) and Alpine being hardened.